### PR TITLE
Add same site none to set-cookie

### DIFF
--- a/.github/workflows/docker-next.yml
+++ b/.github/workflows/docker-next.yml
@@ -2,8 +2,8 @@ name: Publish Next Docker image
 
 on:
   push:
-    # branches:
-    #   - main
+    branches:
+      - main
 
 jobs:
   main:


### PR DESCRIPTION
This allows using cookies obtained from one domain when requesting from another. This change has been tested from `play.decentraland.org` when getting a Cookie from `peer-uw-1.decentraland.org` then the same Cookie was set while getting content from `peer-uw-1.decentraland.org`.